### PR TITLE
Use BuildKit and branching Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 
 # Except shadow jar
 !build/libs/*.jar
+!src/
+!gradle*
+!*gradle.kts
+!buildSrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM navikt/java:11
+FROM navikt/java:11 AS base
 
-COPY build/libs/*.jar app.jar
+FROM base AS dev-env
+COPY . /app
+RUN /app/gradlew build
+
+FROM base AS release
+COPY build/libs/*.jar /app/app.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     VERSION = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
     DOCKER_REPO = 'repo.adeo.no:5443/'
     DOCKER_IMAGE_VERSION = '${DOCKER_REPO}${APPLICATION_NAME}:${VERSION}'
+    DOCKER_BUILDKIT=1
   }
 
   stages {


### PR DESCRIPTION
Locally it would be better to be able to build the project internally in the Dockerfile so it cooperates better with tools like Docker-Compose.

But as long as Jenkins is our CI, it is a hassle setting up proxy and certificates inside the docker build process, so there it is better to build on the outside, and copy built artifacts in.

BuildKit allows branched Dockerfiles, and will only build the necessary branches. This PR makes a separate branch for building inside Docker, so docker-compose can work seamlessly.